### PR TITLE
Handle secondary address in InstrumentAddress and add two options

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -15,7 +15,6 @@ import (
 
 // Controller models a GPIB controller-in-charge.
 type Controller struct {
-	Debug            bool // if true, print controller commands before sending
 	rw               io.ReadWriter
 	primaryAddr      int
 	hasSecondaryAddr bool

--- a/examples/vcp/ds345/main.go
+++ b/examples/vcp/ds345/main.go
@@ -29,7 +29,7 @@ func init() {
 		"Serial port for Prologix VCP GPIB controller",
 	)
 
-	flag.IntVar(&gpibAddress, "gpib", 6, "GPIB address for the Keysight 33220A")
+	flag.IntVar(&gpibAddress, "gpib", 6, "GPIB address for the SRS DS345")
 }
 
 func main() {
@@ -44,14 +44,14 @@ func main() {
 	}
 
 	// Create a new GPIB controller using the aforementioned serial port and
-	// communicating with the instrument at GPIB address 4.
+	// communicating with the instrument at the given address.
 	gpib, err := prologix.NewController(vcp, gpibAddress, false)
 	if err != nil {
 		log.Fatalf("NewController error: %s", err)
 	}
 
 	// Query the GPIB instrument address.
-	addr, err := gpib.InstrumentAddress()
+	addr, _, err := gpib.InstrumentAddress()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/vcp/e3631a/main.go
+++ b/examples/vcp/e3631a/main.go
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	// Query the GPIB instrument address.
-	addr, err := gpib.InstrumentAddress()
+	addr, _, err := gpib.InstrumentAddress()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/vcp/fluke45/main.go
+++ b/examples/vcp/fluke45/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// Query the GPIB instrument address.
-	addr, err := gpib.InstrumentAddress()
+	addr, _, err := gpib.InstrumentAddress()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/vcp/key33220a/main.go
+++ b/examples/vcp/key33220a/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	// Query the GPIB instrument address.
-	addr, err := gpib.InstrumentAddress()
+	addr, _, err := gpib.InstrumentAddress()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.21
 require (
 	github.com/gotmc/query v0.5.0
 	go.bug.st/serial v1.6.2
+	go.uber.org/multierr v1.11.0
 )
 
 require (
 	github.com/creack/goselect v0.1.2 // indirect
-	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gotmc/query v0.5.0 h1:3du4felYwincLk1iFN26hkTv+yPajI3AxIwsEpdqRdc=
 github.com/gotmc/query v0.5.0/go.mod h1:5Fe+Q3az2zfXXa4pdvQ95mgieY6Bf/XFEOyMtdKjukE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -10,7 +10,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.bug.st/serial v1.6.2 h1:kn9LRX3sdm+WxWKufMlIRndwGfPWsH1/9lCWXQCasq8=
 go.bug.st/serial v1.6.2/go.mod h1:UABfsluHAiaNI+La2iESysd9Vetq7VRdpxvjx7CmmOE=
-golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 h1:v6hYoSR9T5oet+pMXwUWkbiVqx/63mlHjefrHmxwfeY=
-golang.org/x/sys v0.0.0-20220829200755-d48e67d00261/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Let me know if you would prefer these 3 commits to be separate PRs.

* WithAR488 option: compatibility with the Arduino-based AR488
   * This adjusts the init command sequence to play nicely with the AR488.
* WithDebug option: log commands and responses
* InstrumentAddress: handle secondary address
    * Note that two "soft" errors are introduced to report an internal state mismatch (configured vs reported address). Let me know if you'd prefer to ignore them or handle them differently. 
    * In addition, this fixes a couple typos in the DS345 example.